### PR TITLE
Check error string with lower case

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -12,7 +12,7 @@ branch, error = gitsym.communicate()
 
 error_string = error.decode('utf-8')
 
-if 'fatal: Not a git repository' in error_string:
+if 'fatal: not a git repository' in error_string.lower():
 	sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]


### PR DESCRIPTION
From git 2.17.0, it appears that the error string changes.
https://github.com/olivierverdier/zsh-git-prompt/pull/117